### PR TITLE
[JOS-65] add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# This file registers ownership for the code.
+# Review from a member of the corresponding code owner is required to merge pull requests.
+#
+# The last matching pattern takes precedence.
+# https://help.github.com/articles/about-codeowners/
+
+* @nordeck/jitsi

--- a/.releaserc
+++ b/.releaserc
@@ -8,20 +8,6 @@
 
     ["@semantic-release/exec", {
           "publishCmd": "echo RELEASE_VERSION=${nextRelease.version} >> $GITHUB_OUTPUT"
-        }],
-
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"]
-      }
-    ]
+        }]
   ]
 }


### PR DESCRIPTION
[JOS-65]
- more restrictive branch protection rules have been applied
  
  `main`:
  - force pushes are blocked
  - `main` requires 1 approval from code owners
  - none may bypass these rules

   release branches: 
  - creation, updates, deletion my only be done by Org admins, Deploy keys, Maintainer (Role), Write (Role) and Jitsi Team
  - PRs requires approval from code owners
  - force pushes are blocked
- CODEOWNERS file to make sure you guys can manage and merge code

If semantic release has issues, it may have to be added as a Github App

[JOS-65]: https://nordeck.atlassian.net/browse/JOS-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ